### PR TITLE
fix(builder): wrong optional properties with data & interface

### DIFF
--- a/src/EntityBuilder.ts
+++ b/src/EntityBuilder.ts
@@ -4,10 +4,10 @@ export class EntityBuilder {
   /**
      * Build an entity object from source data.
      */
-  public static buildOne<T extends any, S extends Omit<T, 'fromJson'|'toJson'>> (BuildClass: new () => T, sourceData: S): Required<T | S> {
+  public static buildOne<T extends any, S extends Omit<T, 'fromJson'|'toJson'>> (BuildClass: new () => T, sourceData: S): Required<T> | S {
     this.checkClassValidity(BuildClass)
 
-    const entity: any = new BuildClass()
+    const entity: T = new BuildClass()
 
     // we ensure that `fromJson` is available as this
     // could simply be annotated with `@Type(Object)`
@@ -15,14 +15,14 @@ export class EntityBuilder {
       entity.fromJson(sourceData)
       return entity
     } else {
-      return sourceData as Required<T & S>
+      return sourceData as Required<T> | S
     }
   }
 
   /**
      * Build multiple entities from an array of source data.
      */
-  public static buildMany<T extends any, S extends Omit<T, 'fromJson'|'toJson'>> (BuildClass: new () => T, sourceData: S[]): Array<Required<T | S>> {
+  public static buildMany<T extends any, S extends Omit<T, 'fromJson'|'toJson'>> (BuildClass: new () => T, sourceData: S[]): Array<Required<T> | S> {
     this.checkClassValidity(BuildClass)
 
     return sourceData.map(entityData => this.buildOne<T, S>(BuildClass, entityData))


### PR DESCRIPTION
Fixed a bug where non-provided optional properties were converted to required (`string | undefined` => `string`) when the JSON data fed in `EntityBuilder` was implementing an interface (because of `Required<T | S>` instead of `Required<T> | S`).